### PR TITLE
Fix: add wrap to text in a-tags on the service pages

### DIFF
--- a/client/src/Components/Pages/Services/LocalServices/LocalServices.tsx
+++ b/client/src/Components/Pages/Services/LocalServices/LocalServices.tsx
@@ -150,7 +150,7 @@ const LocalServices = () => {
                 <hr></hr>
                 {currentPractice.URL && (
                   <a
-                    className="pl-2 text-blue hover:text-underline"
+                    className="pl-2 text-blue hover:text-underline break-all"
                     href={currentPractice.URL}
                   >
                     {currentPractice.URL}

--- a/client/src/Components/Pages/Services/TranslateTerms/TranslateTerms.tsx
+++ b/client/src/Components/Pages/Services/TranslateTerms/TranslateTerms.tsx
@@ -233,7 +233,7 @@ const TranslateTerms = () => {
             <p className="text-center z-10 font-semibold text-gray-800">
               {displayTerm.description}
             </p>
-            <a className="text-blue-dark z-10" href={displayTerm.url}>
+            <a className="text-blue-dark text-center z-10 break-all" href={displayTerm.url}>
               {displayTerm.url}
             </a>
             <img


### PR DESCRIPTION
The a-tag text on mobile on the service pages were over-running, so added a word wrap to the style.